### PR TITLE
Added several additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /nbproject/private/
+*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /nbproject/private/
 *.xml
+*.properties

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The map can then be zoomed and panned to fit exactly what needs to be printed.
 3. Add the map control:
     ```javascript
     //Assumes your id is #map. If you have a different id pass it to PrinPreview
-    //L.PrintPreview('#map_id').addTo(map);
+    //L.PrintPreview({mapID:'#map_id'}).addTo(map);
     L.PrintPreview().addTo(map);
     ```
 ## Complete Example
@@ -64,9 +64,17 @@ Here is everything you need to get this up and running. Copy and past the follow
 Checkout the [DEMO](https://marcchasse.github.io/Leaflet.PrintPreview/)
 
 ## Options
-`mapID`: The id of the map. Default: `#map`
-`mainID`: The id of the main css file. Default: `#pp-main`
-`landscapeID`: The id of the landscape css file. Default: `#pp-ltr-land`
-`portaitID`: The id of the portrait css file. Default: `#pp-ltr-port`
-`toggle`: An array of id's or classes of items that should be toggled
+`mapID`: The id of the map. Default: `#map`.
+
+`mainID`: The id of the main css file. Default: `#pp-main`.
+
+`landscapeID`: The id of the landscape css file. Default: `#pp-ltr-land`.
+
+`portaitID`: The id of the portrait css file. Default: `#pp-ltr-port`.
+
+`toggle`: An array of id's or classes of items that should be toggled when the preview is triggered.
+
+`callback`: A callback function after the preview has been created.
+
+`addScale`: Set to true to add a scale to the bottom left corner of map.
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ The map can then be zoomed and panned to fit exactly what needs to be printed.
 2. Include PrintPreview javascript and css
 
     ```html
-    <link rel="stylesheet" type="text/css" href="https://rawgit.com/MarcChasse/leaflet.PrintPreview/master/leaflet.printpreview.css" disabled>
-    <link rel="stylesheet" type="text/css" href="https://rawgit.com/MarcChasse/leaflet.PrintPreview/master/leaflet.printpreview.letter.landscape.css" disabled>
-    <link rel="stylesheet" type="text/css" href="https://rawgit.com/MarcChasse/leaflet.PrintPreview/master/leaflet.printpreview.letter.portrait.css" disabled>
-    <script src="https://rawgit.com/MarcChasse/Leaflet.PrintPreview/master/leaflet.printpreview.js"></script>
+    <link id="pp-main" rel="stylesheet" href="./leaflet.printpreview.css" disabled>
+    <link id="pp-ltr-land" rel="stylesheet" href="./leaflet.printpreview.letter.landscape.css" disabled>
+    <link id="pp-ltr-port" rel="stylesheet" href="./leaflet.printpreview.letter.portrait.css" disabled>
+    <script src="./leaflet.printpreview.js"></script>
     ```
 3. Add the map control:
     ```javascript
+    //Assumes your id is #map. If you have a different id pass it to PrinPreview
+    //L.PrintPreview('#map_id').addTo(map);
     L.PrintPreview().addTo(map);
     ```
 ## Complete Example

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The map can then be zoomed and panned to fit exactly what needs to be printed.
 2. Include PrintPreview javascript and css
 
     ```html
-    <link id="pp-main" rel="stylesheet" href="./leaflet.printpreview.css" disabled>
-    <link id="pp-ltr-land" rel="stylesheet" href="./leaflet.printpreview.letter.landscape.css" disabled>
-    <link id="pp-ltr-port" rel="stylesheet" href="./leaflet.printpreview.letter.portrait.css" disabled>
+    <link id="pp-main" rel="stylesheet" href="./leaflet.printpreview.css">
+    <link id="pp-ltr-land" rel="stylesheet" href="./leaflet.printpreview.letter.landscape.css">
+    <link id="pp-ltr-port" rel="stylesheet" href="./leaflet.printpreview.letter.portrait.css">
     <script src="./leaflet.printpreview.js"></script>
     ```
 3. Add the map control:
@@ -64,4 +64,9 @@ Here is everything you need to get this up and running. Copy and past the follow
 Checkout the [DEMO](https://marcchasse.github.io/Leaflet.PrintPreview/)
 
 ## Options
-TBD.
+`mapID`: The id of the map. Default: `#map`
+`mainID`: The id of the main css file. Default: `#pp-main`
+`landscapeID`: The id of the landscape css file. Default: `#pp-ltr-land`
+`portaitID`: The id of the portrait css file. Default: `#pp-ltr-port`
+`toggle`: An array of id's or classes of items that should be toggled
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>Leaflet.PrintPreview DEMO</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
+    <link id="pp-main" rel="stylesheet" href="./leaflet.printpreview.css" disabled>
+    <link id="pp-ltr-land" rel="stylesheet" href="./leaflet.printpreview.letter.landscape.css" disabled>
+    <link id="pp-ltr-port" rel="stylesheet" href="./leaflet.printpreview.letter.portrait.css" disabled>
+    <style>html,body{margin:0;}#map_{width:100vw;height:100vh;}</style>
+</head>
+<body>
+    <div id="map_" ></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script src="./leaflet.printpreview.js"></script>
+    <script>
+        osm = new L.TileLayer(
+            'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            {attribution: 'Map data &copy; OpenStreetMap contributors'}
+        );
+
+        var map = L.map('map_', {
+            center: [52.27,-113.81],
+            zoom: 12
+        });
+        map.addLayer(osm);
+
+        L.PrintPreview({
+            mapID: '#map_'
+        }).addTo(map);
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,13 +6,15 @@
     <title>Leaflet.PrintPreview DEMO</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
-    <link id="pp-main" rel="stylesheet" href="./leaflet.printpreview.css" disabled>
-    <link id="pp-ltr-land" rel="stylesheet" href="./leaflet.printpreview.letter.landscape.css" disabled>
-    <link id="pp-ltr-port" rel="stylesheet" href="./leaflet.printpreview.letter.portrait.css" disabled>
+    <link id="pp-main" rel="stylesheet" href="./leaflet.printpreview.css">
+    <link id="pp-ltr-port" rel="stylesheet" href="./leaflet.printpreview.letter.portrait.css">
+    <link id="pp-ltr-land" rel="stylesheet" href="./leaflet.printpreview.letter.landscape.css">
     <style>html,body{margin:0;}#map_{width:100vw;height:100vh;}</style>
 </head>
 <body>
     <div id="map_" ></div>
+    <div id="hi" style="position: absolute; font-size: 40px; left: 200px; top: 200px; z-index: 99999">HI</div>
+    <div id="hello" style="position: absolute; font-size: 40px; left: 200px; top: 200px; z-index: 99999">HELLO</div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="./leaflet.printpreview.js"></script>
@@ -29,8 +31,10 @@
         map.addLayer(osm);
 
         L.PrintPreview({
-            mapID: '#map_'
+            mapID: '#map_',
+            toggle: ['#hi', '#hello']
         }).addTo(map);
+        $('#hello').hide();
     </script>
 </body>
 </html>

--- a/leaflet.printpreview.js
+++ b/leaflet.printpreview.js
@@ -7,6 +7,7 @@
     //other globals
     var toggle;
     var scale;
+    
     /**
      * Hides and shows objects when preview mode is triggered
      */
@@ -59,7 +60,8 @@
         reCenterMap(center);
         
         //remove the scale
-        scale.remove();
+        if(typeof scale !== undefined)
+            scale.remove();
     }
 
     L.Control.PrintPreview = L.Control.extend({
@@ -80,7 +82,7 @@
             return container;
         },
 
-        PrintPreview: function (options) {
+        PrintPreview: function () {
             'use strict';
             //set the map id but assume #map for backwards compatibility
             var center = map.getCenter();
@@ -109,7 +111,12 @@
             reCenterMap(center);
             
             //add the scale to map
-            scale = L.control.scale().addTo(map);
+            if(this.addScale)
+                scale = L.control.scale().addTo(map);
+            
+            //call callback if defined
+            if(typeof this.callback === 'function')
+                this.callback.call(this, $map, $portrait, $landscape);
         }
     });
 

--- a/leaflet.printpreview.js
+++ b/leaflet.printpreview.js
@@ -1,5 +1,20 @@
 (function() {
-    var mapID;
+    //the jQueryfied objects
+    var $map;
+    var $main;
+    var $landscape;
+    var $portrait;
+    //other globals
+    var toggle;
+    
+    /**
+     * Hides and shows objects when preview mode is triggered
+     */
+    function toggleObjects() {
+        $(toggle).each(function(i, e) {
+            $(e).toggle();
+        });
+    }
     
     function reCenterMap(center) {
         'use strict';
@@ -12,15 +27,15 @@
         var center = map.getCenter();
 
         var swapfile = document.getElementById("printpreview-swapFile");
-        if($('#pp-ltr-land').prop('disabled')){
-            $('#pp-ltr-port').attr('disabled','disabled');
-            $('#pp-ltr-land').removeAttr('disabled');
+        if($landscape.prop('disabled')){
+            $portrait.attr('disabled','disabled');
+            $landscape.removeAttr('disabled');
             swapfile.children[0].className = swapfile.children[0].className.replace(/\ fa-rotate-90/g, "");
             swapfile.innerHTML = swapfile.innerHTML.replace(/Landscape/g, "Portrait");
         }
         else {
-            $('#pp-ltr-port').removeAttr('disabled');
-            $('#pp-ltr-land').attr('disabled','disabled');
+            $portrait.removeAttr('disabled');
+            $landscape.attr('disabled','disabled');
             swapfile.children[0].className += " fa-rotate-90";
             swapfile.innerHTML = swapfile.innerHTML.replace(/Portrait/g, "Landscape");
         }
@@ -31,14 +46,16 @@
     function cancelPrintPreview() {
         'use strict';
         var center = map.getCenter();
-        $('#pp-main').attr('disabled','disabled');
-        $('#pp-ltr-land').attr('disabled','disabled');
-        $('#pp-ltr-port').attr('disabled','disabled');
-        $(mapID).unwrap().unwrap();
+        $main.attr('disabled','disabled');
+        $landscape.attr('disabled','disabled');
+        $portrait.attr('disabled','disabled');
+        $map.unwrap().unwrap();
         $('.leaflet-control-printpreview-bar').remove();
-        $(mapID).removeClass('previewmap');
-
-
+        $map.removeClass('previewmap');
+        
+        //toggle all invisible and invisible object
+        toggleObjects();
+            
         reCenterMap(center);
     }
 
@@ -64,20 +81,48 @@
             'use strict';
             //set the map id but assume #map for backwards compatibility
             var center = map.getCenter();
-
             //add print preview elements
-            $(mapID).addClass('previewmap');
-            $(mapID).wrap('<div class="book"><div class="page"></div></div>');
-            $(mapID).before('<div class="leaflet-control-printpreview-bar"><a class="leaflet-control-printpreview-btn" href="#" onclick="window.print();"><i class="fa fa-print fa-lg" aria-hidden="true"></i>&nbsp;Print</a><a id="printpreview-swapFile" class="leaflet-control-printpreview-btn" href="#" onclick="SwapOrientation();"><i class="fa fa-file-o fa-lg fa-rotate-90" aria-hidden="true"></i>&nbsp;Landscape</a><a class="leaflet-control-printpreview-btn" href="#" onclick="cancelPrintPreview();"><i class="fa fa-times-circle" aria-hidden="true"></i>&nbsp;Cancel Preview</a></div>');
-            $('#pp-main').removeAttr('disabled');
-            $('#pp-ltr-port').removeAttr('disabled');
-
+            $map.addClass('previewmap');
+            $map.wrap('<div class="book"><div class="page"></div></div>');
+            $map.before(
+                '<div class="leaflet-control-printpreview-bar">'+
+                    '<a class="leaflet-control-printpreview-btn" href="#" onclick="window.print();">'+
+                        '<i class="fa fa-print fa-lg" aria-hidden="true"></i>&nbsp;Print'+
+                    '</a>'+
+                    '<a id="printpreview-swapFile" class="leaflet-control-printpreview-btn" href="javascript:void(0)">'+
+                        '<i class="fa fa-file-o fa-lg fa-rotate-90" aria-hidden="true"></i>&nbsp;Portrait'+
+                    '</a>'+
+                    '<a id="cancel-preview" class="leaflet-control-printpreview-btn" href="javascript:void(0)">'+
+                        '<i class="fa fa-times-circle" aria-hidden="true"></i>&nbsp;Cancel Preview'+
+                    '</a>'+
+                '</div>'
+            );
+            $main.removeAttr('disabled');
+            $landscape.removeAttr('disabled');
+            
+            //toggle all invisible and invisible object
+            toggleObjects();
+            
             reCenterMap(center);
         }
     });
 
     L.PrintPreview = function (options) {
-        mapID = options && options.mapID ? options.mapID : '#map';
+        options = options || {}; //default to blank object
+        //grab the map, main, landscape, and portrait and store them
+        $map = $(options.mapID || '#map');
+        $main = $(options.mainID || '#pp-main').attr('disabled','disabled');
+        $landscape = $(options.landscapeID || '#pp-ltr-land').attr('disabled','disabled');
+        $portrait = $(options.portraitID || '#pp-ltr-port').attr('disabled','disabled');
+        
+        //grab the objects that get toggled with preview
+        toggle = options.toggle || [];
+        
+        //bind the preview window buttons
+        $('body').on('click', '#printpreview-swapFile', SwapOrientation);
+        $('body').on('click', '#cancel-preview', cancelPrintPreview);
+        
+        //Launch
         return new L.Control.PrintPreview(options);
     };
 })();

--- a/leaflet.printpreview.js
+++ b/leaflet.printpreview.js
@@ -6,7 +6,7 @@
     var $portrait;
     //other globals
     var toggle;
-    
+    var scale;
     /**
      * Hides and shows objects when preview mode is triggered
      */
@@ -57,6 +57,9 @@
         toggleObjects();
             
         reCenterMap(center);
+        
+        //remove the scale
+        scale.remove();
     }
 
     L.Control.PrintPreview = L.Control.extend({
@@ -104,6 +107,9 @@
             toggleObjects();
             
             reCenterMap(center);
+            
+            //add the scale to map
+            scale = L.control.scale().addTo(map);
         }
     });
 

--- a/leaflet.printpreview.js
+++ b/leaflet.printpreview.js
@@ -1,77 +1,83 @@
-function reCenterMap(center) {
-    'use strict';
-    map.setView(center, map.getZoom());
-    setTimeout(function () {map.invalidateSize(true);}, 100);
-}
-
-function SwapOrientation() {
-    'use strict';
-    var center = map.getCenter();
-
-    var swapfile = document.getElementById("printpreview-swapFile");
-    if($('#pp-ltr-land').prop('disabled')){
-        $('#pp-ltr-port').attr('disabled','disabled');
-        $('#pp-ltr-land').removeAttr('disabled');
-        swapfile.children[0].className = swapfile.children[0].className.replace(/\ fa-rotate-90/g, "");
-        swapfile.innerHTML = swapfile.innerHTML.replace(/Landscape/g, "Portrait");
-    }
-    else {
-        $('#pp-ltr-port').removeAttr('disabled');
-        $('#pp-ltr-land').attr('disabled','disabled');
-        swapfile.children[0].className += " fa-rotate-90";
-        swapfile.innerHTML = swapfile.innerHTML.replace(/Portrait/g, "Landscape");
-    }
-
-    reCenterMap(center);
-}
-
-function cancelPrintPreview() {
-    'use strict';
-    var center = map.getCenter();
-    $('#pp-main').attr('disabled','disabled');
-    $('#pp-ltr-land').attr('disabled','disabled');
-    $('#pp-ltr-port').attr('disabled','disabled');
-    $('#map').unwrap().unwrap();
-    $('.leaflet-control-printpreview-bar').remove();
-    $('#map').removeClass('previewmap');
-
-
-    reCenterMap(center);
-}
-
-L.Control.PrintPreview = L.Control.extend({
-    options: {
-        title: 'Print preview',
-        position: 'topleft'
-    },
-
-    onAdd: function () {
+(function() {
+    var mapID;
+    
+    function reCenterMap(center) {
         'use strict';
-        //create button and setup click listner
-        var container = L.DomUtil.create('div', 'leaflet-bar leaflet-control');
-        this.link = L.DomUtil.create('a', 'leaflet-control-PrintPreview-button leaflet-bar-part', container);
-        L.DomUtil.create('i', 'fa fa-print fa-lg', this.link);
-        this.link.title = this.options.title;
+        map.setView(center, map.getZoom());
+        setTimeout(function () {map.invalidateSize(true);}, 100);
+    }
 
-        L.DomEvent.addListener(this.link, 'click', this.PrintPreview, this.options);
-        return container;
-    },
-
-    PrintPreview: function () {
+    function SwapOrientation() {
         'use strict';
         var center = map.getCenter();
 
-        //add print preview elements
-        $('#map').addClass('previewmap');
-        $('#map').wrap('<div class="book"><div class="page"></div></div>');
-        $('#map').before('<div class="leaflet-control-printpreview-bar"><a class="leaflet-control-printpreview-btn" href="#" onclick="window.print();"><i class="fa fa-print fa-lg" aria-hidden="true"></i>&nbsp;Print</a><a id="printpreview-swapFile" class="leaflet-control-printpreview-btn" href="#" onclick="SwapOrientation();"><i class="fa fa-file-o fa-lg fa-rotate-90" aria-hidden="true"></i>&nbsp;Landscape</a><a class="leaflet-control-printpreview-btn" href="#" onclick="cancelPrintPreview();"><i class="fa fa-times-circle" aria-hidden="true"></i>&nbsp;Cancel Preview</a></div>');
-        $('#pp-main').removeAttr('disabled');
-        $('#pp-ltr-port').removeAttr('disabled');
+        var swapfile = document.getElementById("printpreview-swapFile");
+        if($('#pp-ltr-land').prop('disabled')){
+            $('#pp-ltr-port').attr('disabled','disabled');
+            $('#pp-ltr-land').removeAttr('disabled');
+            swapfile.children[0].className = swapfile.children[0].className.replace(/\ fa-rotate-90/g, "");
+            swapfile.innerHTML = swapfile.innerHTML.replace(/Landscape/g, "Portrait");
+        }
+        else {
+            $('#pp-ltr-port').removeAttr('disabled');
+            $('#pp-ltr-land').attr('disabled','disabled');
+            swapfile.children[0].className += " fa-rotate-90";
+            swapfile.innerHTML = swapfile.innerHTML.replace(/Portrait/g, "Landscape");
+        }
 
         reCenterMap(center);
     }
-});
 
-L.PrintPreview = function (options) {
-    return new L.Control.PrintPreview(options);
-};
+    function cancelPrintPreview() {
+        'use strict';
+        var center = map.getCenter();
+        $('#pp-main').attr('disabled','disabled');
+        $('#pp-ltr-land').attr('disabled','disabled');
+        $('#pp-ltr-port').attr('disabled','disabled');
+        $(mapID).unwrap().unwrap();
+        $('.leaflet-control-printpreview-bar').remove();
+        $(mapID).removeClass('previewmap');
+
+
+        reCenterMap(center);
+    }
+
+    L.Control.PrintPreview = L.Control.extend({
+        options: {
+            title: 'Print preview',
+            position: 'topleft'
+        },
+
+        onAdd: function () {
+            'use strict';
+            //create button and setup click listner
+            var container = L.DomUtil.create('div', 'leaflet-bar leaflet-control');
+            this.link = L.DomUtil.create('a', 'leaflet-control-PrintPreview-button leaflet-bar-part', container);
+            L.DomUtil.create('i', 'fa fa-print fa-lg', this.link);
+            this.link.title = this.options.title;
+
+            L.DomEvent.addListener(this.link, 'click', this.PrintPreview, this.options);
+            return container;
+        },
+
+        PrintPreview: function (options) {
+            'use strict';
+            //set the map id but assume #map for backwards compatibility
+            var center = map.getCenter();
+
+            //add print preview elements
+            $(mapID).addClass('previewmap');
+            $(mapID).wrap('<div class="book"><div class="page"></div></div>');
+            $(mapID).before('<div class="leaflet-control-printpreview-bar"><a class="leaflet-control-printpreview-btn" href="#" onclick="window.print();"><i class="fa fa-print fa-lg" aria-hidden="true"></i>&nbsp;Print</a><a id="printpreview-swapFile" class="leaflet-control-printpreview-btn" href="#" onclick="SwapOrientation();"><i class="fa fa-file-o fa-lg fa-rotate-90" aria-hidden="true"></i>&nbsp;Landscape</a><a class="leaflet-control-printpreview-btn" href="#" onclick="cancelPrintPreview();"><i class="fa fa-times-circle" aria-hidden="true"></i>&nbsp;Cancel Preview</a></div>');
+            $('#pp-main').removeAttr('disabled');
+            $('#pp-ltr-port').removeAttr('disabled');
+
+            reCenterMap(center);
+        }
+    });
+
+    L.PrintPreview = function (options) {
+        mapID = options && options.mapID ? options.mapID : '#map';
+        return new L.Control.PrintPreview(options);
+    };
+})();


### PR DESCRIPTION
* Wrapped library in self executing function. This removes the library functions from the global namespace
* Removed hard coded map id. This can now be optionally changed with the `mapID` option
* Fixed README.MD to now show the correct way of add css and js files. Previous example didn't include the id and used the rawgit links to repository
* Added `callback` option (see README.MD)
* Added  `addScale` option. This adds a scale to the map. This currently has not positioning option and should be added.
* Click events for preview buttons are no longer hard coded to button and are dynamically bound.